### PR TITLE
feat: lazy load article images

### DIFF
--- a/docs/superpowers/plans/2026-05-23-lazy-load-article-images.md
+++ b/docs/superpowers/plans/2026-05-23-lazy-load-article-images.md
@@ -1,0 +1,164 @@
+# Lazy Load Article Images Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 讓 VitePress 文章內容產生的圖片自動帶上 `loading="lazy"`，並保留既有 `loading` 設定。
+
+**Architecture:** 把圖片屬性補強邏輯抽成一個獨立 markdown helper，讓 VitePress `markdown.config` 同時套用在 Markdown 圖片 renderer 與文章內嵌 HTML `<img>` token。用 Node 內建測試驗證屬性補強邏輯，避免引入額外測試框架。
+
+**Tech Stack:** VitePress 1.x、markdown-it、Node.js built-in test runner
+
+---
+
+### Task 1: 建立圖片 lazy-loading helper 與測試
+
+**Files:**
+- Create: `pages/.vitepress/markdown/lazy-images.js`
+- Create: `tests/lazy-images.test.js`
+
+- [ ] **Step 1: 寫失敗測試**
+
+```js
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  addLazyLoadingToImageTag,
+  addLazyLoadingToHtmlContent
+} from '../pages/.vitepress/markdown/lazy-images.js'
+
+test('adds loading lazy to img tag without loading attribute', () => {
+  const result = addLazyLoadingToImageTag('<img src="/cover.png" alt="cover">')
+  assert.match(result, /loading="lazy"/)
+})
+
+test('keeps existing loading attribute on img tag', () => {
+  const result = addLazyLoadingToImageTag('<img src="/cover.png" loading="eager">')
+  assert.match(result, /loading="eager"/)
+  assert.doesNotMatch(result, /loading="lazy".*loading="eager"|loading="eager".*loading="lazy"/)
+})
+
+test('adds loading lazy to html content img tags', () => {
+  const result = addLazyLoadingToHtmlContent('<p>demo</p><img src="/cover.png">')
+  assert.match(result, /<img[^>]*loading="lazy"/)
+})
+```
+
+- [ ] **Step 2: 跑測試確認失敗**
+
+Run: `node --test tests/lazy-images.test.js`  
+Expected: FAIL，因為 helper 尚未建立
+
+- [ ] **Step 3: 寫最小實作**
+
+```js
+const IMG_TAG_PATTERN = /<img\b[^>]*>/gi
+const LOADING_ATTR_PATTERN = /\sloading\s*=/i
+
+export function addLazyLoadingToImageTag(imgTag) {
+  if (LOADING_ATTR_PATTERN.test(imgTag)) {
+    return imgTag
+  }
+
+  return imgTag.replace('<img', '<img loading="lazy"')
+}
+
+export function addLazyLoadingToHtmlContent(content) {
+  return content.replace(IMG_TAG_PATTERN, addLazyLoadingToImageTag)
+}
+```
+
+- [ ] **Step 4: 跑測試確認通過**
+
+Run: `node --test tests/lazy-images.test.js`  
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/lazy-images.test.js pages/.vitepress/markdown/lazy-images.js
+git commit -m "test: cover lazy-loading image helpers"
+```
+
+### Task 2: 接上 VitePress markdown renderer
+
+**Files:**
+- Modify: `pages/.vitepress/config.js`
+- Test: `tests/lazy-images.test.js`
+
+- [ ] **Step 1: 補一個 renderer/HTML token 整合測試**
+
+```js
+import MarkdownIt from 'markdown-it'
+
+import { applyLazyImageLoading } from '../pages/.vitepress/markdown/lazy-images.js'
+
+test('adds loading lazy for markdown image renderer output', () => {
+  const md = new MarkdownIt()
+  applyLazyImageLoading(md)
+
+  const result = md.render('![cover](/cover.png)')
+  assert.match(result, /<img[^>]*loading="lazy"/)
+})
+```
+
+- [ ] **Step 2: 跑測試確認失敗**
+
+Run: `node --test tests/lazy-images.test.js`  
+Expected: FAIL，因為 `applyLazyImageLoading` 尚未實作
+
+- [ ] **Step 3: 在 helper 與 VitePress config 寫最小整合**
+
+```js
+export function applyLazyImageLoading(md) {
+  const defaultImageRenderer =
+    md.renderer.rules.image ||
+    ((tokens, idx, options, env, self) => self.renderToken(tokens, idx, options))
+
+  md.renderer.rules.image = (tokens, idx, options, env, self) => {
+    const token = tokens[idx]
+
+    if (token.attrIndex('loading') === -1) {
+      token.attrSet('loading', 'lazy')
+    }
+
+    return defaultImageRenderer(tokens, idx, options, env, self)
+  }
+
+  md.core.ruler.push('lazy_article_html_images', (state) => {
+    state.tokens.forEach((token) => {
+      if (token.type === 'html_block' || token.type === 'html_inline') {
+        token.content = addLazyLoadingToHtmlContent(token.content)
+      }
+    })
+  })
+}
+```
+
+```js
+import { applyLazyImageLoading } from './markdown/lazy-images.js'
+
+markdown: {
+  // existing options...
+  config: (md) => {
+    applyLazyImageLoading(md)
+  }
+}
+```
+
+- [ ] **Step 4: 跑測試確認通過**
+
+Run: `node --test tests/lazy-images.test.js`  
+Expected: PASS
+
+- [ ] **Step 5: 跑建置驗證整體輸出**
+
+Run: `npm run pages:build`  
+Expected: exit 0，且輸出的文章 HTML 內文圖片包含 `loading="lazy"`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pages/.vitepress/config.js pages/.vitepress/markdown/lazy-images.js tests/lazy-images.test.js
+git commit -m "feat: lazy load article images"
+```

--- a/docs/superpowers/specs/2026-05-23-lazy-load-article-images-design.md
+++ b/docs/superpowers/specs/2026-05-23-lazy-load-article-images-design.md
@@ -1,0 +1,67 @@
+# 文章內容圖片自動加上 lazy loading 設計
+
+## 目標
+
+讓本專案文章內容產生的 `<img>` 自動帶有 `loading="lazy"`，提升文章頁圖片的初始載入效率，同時不影響主題元件、導覽、logo 或其他非文章內容圖片。
+
+## 範圍
+
+- 包含：
+  - Markdown 圖片語法產生的文章圖片
+  - 文章正文中直接撰寫的 HTML `<img>`
+- 不包含：
+  - VitePress 主題元件內的圖片
+  - 站台 logo、導覽列圖示、其他 layout 圖片
+  - 站外嵌入內容（如 iframe）
+
+## 現況
+
+- 站台使用 VitePress，Markdown 設定集中在 `pages/.vitepress/config.js`
+- 文章來源同時包含手寫 Markdown 與由 `scripts/build-posts.js` 生成的貼文內容
+- 既有文章中已存在直接撰寫的 HTML `<img>`，因此只修改文章生成腳本不足以完整覆蓋需求
+
+## 採用方案
+
+在 `pages/.vitepress/config.js` 的 `markdown.config` 中擴充 markdown-it 行為：
+
+1. 覆寫 Markdown 圖片 renderer，讓 Markdown 圖片輸出的 `<img>` 自動補上 `loading="lazy"`
+2. 加入 core rule，巡覽文章內容中的 HTML 區塊，針對 `<img>` 補上 `loading="lazy"`
+3. 若圖片已經明確宣告 `loading` 屬性，保留原值，不覆寫
+
+## 為什麼選這個方案
+
+- 修改點集中在 VitePress 文章 renderer，能精準限定在文章內容
+- 可同時覆蓋 Markdown 圖片與內嵌 HTML `<img>`
+- 不需要前端 runtime 掃描 DOM，也不需要改動主題元件
+- 對既有文章與未來新文章都生效
+
+## 不採用方案
+
+### 只改 `scripts/build-posts.js`
+
+這只能覆蓋從 GitHub Issues 同步生成的文章，無法處理手寫文章中的 Markdown 圖片或其他手動維護的文章檔。
+
+### 前端 runtime 掃描 DOM 後補屬性
+
+雖然可行，但屬性補得太晚，也增加不必要的前端行為，不符合這個靜態內容站的最小改動原則。
+
+## 風險與處理
+
+- 風險：誤改到非文章內容圖片
+  - 處理：只掛在 VitePress 的 Markdown renderer，不碰 theme component
+- 風險：重複加入 `loading` 屬性
+  - 處理：若原始標籤已帶 `loading`，則直接保留
+- 風險：HTML `<img>` 屬性順序被改動
+  - 處理：只做最小字串補強，避免不必要重寫
+
+## 驗證方式
+
+1. 執行 `npm run pages:build`
+2. 檢查輸出的文章 HTML，確認文章內容中的 `<img>` 帶有 `loading="lazy"`
+3. 抽查至少一篇含 HTML `<img>` 的文章與一篇含一般 Markdown 圖片的文章
+
+## 預期結果
+
+- 文章內容圖片預設 lazy loading
+- 主題與 layout 圖片維持原狀
+- 不需要修改既有文章內容格式

--- a/pages/.vitepress/config.js
+++ b/pages/.vitepress/config.js
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vitepress'
 import seoConfig from '../../seo.config.js'
+import { applyLazyImageLoading } from './markdown/lazy-images.js'
 
 const { site, seo, social } = seoConfig
 
@@ -233,6 +234,9 @@ export default defineConfig({
       permalink: true,
       permalinkBefore: false,
       permalinkSymbol: '#'
+    },
+    config: (md) => {
+      applyLazyImageLoading(md)
     }
   },
 

--- a/pages/.vitepress/markdown/lazy-images.js
+++ b/pages/.vitepress/markdown/lazy-images.js
@@ -1,16 +1,25 @@
 const IMG_TAG_PATTERN = /<img\b[^>]*>/gi
+const IMG_TAG_OPEN_PATTERN = /<img\b/i
 const LOADING_ATTR_PATTERN = /\sloading\s*=/i
+const ARTICLE_PATH_PATTERN = /^posts\/.+\.md$/
+const ARTICLE_FILE_PATH_PATTERN = /\/posts\/.+\.md$/
 
 export function addLazyLoadingToImageTag(imgTag) {
   if (LOADING_ATTR_PATTERN.test(imgTag)) {
     return imgTag
   }
 
-  return imgTag.replace('<img', '<img loading="lazy"')
+  return imgTag.replace(IMG_TAG_OPEN_PATTERN, '$& loading="lazy"')
 }
 
 export function addLazyLoadingToHtmlContent(content) {
   return content.replace(IMG_TAG_PATTERN, addLazyLoadingToImageTag)
+}
+
+export function shouldLazyLoadImages(env) {
+  return ARTICLE_PATH_PATTERN.test(env?.relativePath || '') ||
+    ARTICLE_FILE_PATH_PATTERN.test(env?.path || '') ||
+    ARTICLE_FILE_PATH_PATTERN.test(env?.realPath || '')
 }
 
 export function applyLazyImageLoading(md) {
@@ -19,6 +28,10 @@ export function applyLazyImageLoading(md) {
     ((tokens, idx, options, env, self) => self.renderToken(tokens, idx, options))
 
   md.renderer.rules.image = (tokens, idx, options, env, self) => {
+    if (!shouldLazyLoadImages(env)) {
+      return defaultImageRenderer(tokens, idx, options, env, self)
+    }
+
     const token = tokens[idx]
 
     if (token.attrIndex('loading') === -1) {
@@ -29,6 +42,10 @@ export function applyLazyImageLoading(md) {
   }
 
   md.core.ruler.push('lazy_article_html_images', (state) => {
+    if (!shouldLazyLoadImages(state.env)) {
+      return
+    }
+
     state.tokens.forEach((token) => {
       if (token.type === 'html_block' || token.type === 'html_inline') {
         token.content = addLazyLoadingToHtmlContent(token.content)

--- a/pages/.vitepress/markdown/lazy-images.js
+++ b/pages/.vitepress/markdown/lazy-images.js
@@ -1,0 +1,38 @@
+const IMG_TAG_PATTERN = /<img\b[^>]*>/gi
+const LOADING_ATTR_PATTERN = /\sloading\s*=/i
+
+export function addLazyLoadingToImageTag(imgTag) {
+  if (LOADING_ATTR_PATTERN.test(imgTag)) {
+    return imgTag
+  }
+
+  return imgTag.replace('<img', '<img loading="lazy"')
+}
+
+export function addLazyLoadingToHtmlContent(content) {
+  return content.replace(IMG_TAG_PATTERN, addLazyLoadingToImageTag)
+}
+
+export function applyLazyImageLoading(md) {
+  const defaultImageRenderer =
+    md.renderer.rules.image ||
+    ((tokens, idx, options, env, self) => self.renderToken(tokens, idx, options))
+
+  md.renderer.rules.image = (tokens, idx, options, env, self) => {
+    const token = tokens[idx]
+
+    if (token.attrIndex('loading') === -1) {
+      token.attrSet('loading', 'lazy')
+    }
+
+    return defaultImageRenderer(tokens, idx, options, env, self)
+  }
+
+  md.core.ruler.push('lazy_article_html_images', (state) => {
+    state.tokens.forEach((token) => {
+      if (token.type === 'html_block' || token.type === 'html_inline') {
+        token.content = addLazyLoadingToHtmlContent(token.content)
+      }
+    })
+  })
+}

--- a/tests/lazy-images.test.js
+++ b/tests/lazy-images.test.js
@@ -1,0 +1,79 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  addLazyLoadingToImageTag,
+  addLazyLoadingToHtmlContent,
+  applyLazyImageLoading
+} from '../pages/.vitepress/markdown/lazy-images.js'
+
+function createImageToken(attrs = []) {
+  return {
+    attrs: [...attrs],
+    attrIndex(name) {
+      return this.attrs.findIndex(([attrName]) => attrName === name)
+    },
+    attrSet(name, value) {
+      const index = this.attrIndex(name)
+      if (index === -1) {
+        this.attrs.push([name, value])
+        return
+      }
+
+      this.attrs[index][1] = value
+    }
+  }
+}
+
+test('adds loading lazy to img tag without loading attribute', () => {
+  const result = addLazyLoadingToImageTag('<img src="/cover.png" alt="cover">')
+
+  assert.match(result, /loading="lazy"/)
+})
+
+test('keeps existing loading attribute on img tag', () => {
+  const result = addLazyLoadingToImageTag('<img src="/cover.png" loading="eager">')
+
+  assert.match(result, /loading="eager"/)
+  assert.doesNotMatch(
+    result,
+    /loading="lazy".*loading="eager"|loading="eager".*loading="lazy"/
+  )
+})
+
+test('adds loading lazy to html content img tags', () => {
+  const result = addLazyLoadingToHtmlContent('<p>demo</p><img src="/cover.png">')
+
+  assert.match(result, /<img[^>]*loading="lazy"/)
+})
+
+test('adds loading lazy for markdown image renderer output', () => {
+  const md = {
+    renderer: {
+      rules: {
+        image(tokens, idx) {
+          const attrs = tokens[idx].attrs
+            .map(([name, value]) => `${name}="${value}"`)
+            .join(' ')
+          return `<img ${attrs}>`
+        }
+      }
+    },
+    core: {
+      ruler: {
+        push() {}
+      }
+    }
+  }
+  applyLazyImageLoading(md)
+
+  const result = md.renderer.rules.image(
+    [createImageToken([['src', '/cover.png'], ['alt', 'cover']])],
+    0,
+    {},
+    {},
+    {}
+  )
+
+  assert.match(result, /<img[^>]*loading="lazy"/)
+})

--- a/tests/lazy-images.test.js
+++ b/tests/lazy-images.test.js
@@ -25,10 +25,41 @@ function createImageToken(attrs = []) {
   }
 }
 
+function createMarkdownItMock() {
+  const pushedRules = []
+
+  return {
+    pushedRules,
+    renderer: {
+      rules: {
+        image(tokens, idx) {
+          const attrs = tokens[idx].attrs
+            .map(([name, value]) => `${name}="${value}"`)
+            .join(' ')
+          return `<img ${attrs}>`
+        }
+      }
+    },
+    core: {
+      ruler: {
+        push(_name, rule) {
+          pushedRules.push(rule)
+        }
+      }
+    }
+  }
+}
+
 test('adds loading lazy to img tag without loading attribute', () => {
   const result = addLazyLoadingToImageTag('<img src="/cover.png" alt="cover">')
 
   assert.match(result, /loading="lazy"/)
+})
+
+test('adds loading lazy to uppercase html img tag', () => {
+  const result = addLazyLoadingToImageTag('<IMG src="/cover.png" alt="cover">')
+
+  assert.match(result, /<IMG[^>]*loading="lazy"/)
 })
 
 test('keeps existing loading attribute on img tag', () => {
@@ -48,32 +79,91 @@ test('adds loading lazy to html content img tags', () => {
 })
 
 test('adds loading lazy for markdown image renderer output', () => {
-  const md = {
-    renderer: {
-      rules: {
-        image(tokens, idx) {
-          const attrs = tokens[idx].attrs
-            .map(([name, value]) => `${name}="${value}"`)
-            .join(' ')
-          return `<img ${attrs}>`
-        }
-      }
-    },
-    core: {
-      ruler: {
-        push() {}
-      }
-    }
-  }
+  const md = createMarkdownItMock()
   applyLazyImageLoading(md)
 
   const result = md.renderer.rules.image(
     [createImageToken([['src', '/cover.png'], ['alt', 'cover']])],
     0,
     {},
-    {},
+    { relativePath: 'posts/article.md' },
     {}
   )
 
   assert.match(result, /<img[^>]*loading="lazy"/)
+})
+
+test('does not add loading lazy outside article markdown files', () => {
+  const md = createMarkdownItMock()
+  applyLazyImageLoading(md)
+
+  const result = md.renderer.rules.image(
+    [createImageToken([['src', '/cover.png'], ['alt', 'cover']])],
+    0,
+    {},
+    { relativePath: 'about.md' },
+    {}
+  )
+
+  assert.doesNotMatch(result, /loading="lazy"/)
+})
+
+test('adds loading lazy for article source file paths', () => {
+  const md = createMarkdownItMock()
+  applyLazyImageLoading(md)
+
+  const result = md.renderer.rules.image(
+    [createImageToken([['src', '/cover.png'], ['alt', 'cover']])],
+    0,
+    {},
+    { path: '/repo/pages/posts/article.md' },
+    {}
+  )
+
+  assert.match(result, /loading="lazy"/)
+})
+
+test('adds loading lazy for rewritten article real paths', () => {
+  const md = createMarkdownItMock()
+  applyLazyImageLoading(md)
+
+  const result = md.renderer.rules.image(
+    [createImageToken([['src', '/cover.png'], ['alt', 'cover']])],
+    0,
+    {},
+    {
+      path: '/repo/pages/article.md',
+      relativePath: 'article.md',
+      realPath: '/repo/pages/posts/article.md'
+    },
+    {}
+  )
+
+  assert.match(result, /loading="lazy"/)
+})
+
+test('adds loading lazy to html tokens only for article markdown files', () => {
+  const md = createMarkdownItMock()
+  applyLazyImageLoading(md)
+  const token = { type: 'html_block', content: '<IMG src="/cover.png">' }
+
+  md.pushedRules[0]({
+    env: { relativePath: 'posts/article.md' },
+    tokens: [token]
+  })
+
+  assert.match(token.content, /<IMG[^>]*loading="lazy"/)
+})
+
+test('keeps html tokens unchanged outside article markdown files', () => {
+  const md = createMarkdownItMock()
+  applyLazyImageLoading(md)
+  const token = { type: 'html_block', content: '<img src="/cover.png">' }
+
+  md.pushedRules[0]({
+    env: { relativePath: 'about.md' },
+    tokens: [token]
+  })
+
+  assert.equal(token.content, '<img src="/cover.png">')
 })


### PR DESCRIPTION
## Summary
- Add a VitePress markdown helper to inject `loading="lazy"` into article images.
- Scope the behavior to article content under `pages/posts/` and preserve existing `loading` attributes.
- Cover Markdown images and inline HTML `<img>` with tests.

## Verification
- `node --test tests/lazy-images.test.js`
- `npm run pages:build`